### PR TITLE
Add predefined URLs to update mods from GitHub

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -102,5 +102,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": "ce561cc5-ec0f-4cbc-ab1f-11deb2150f94"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@angular/platform-browser-dynamic": "^15.2.5",
         "@angular/router": "^15.2.5",
         "@angular/service-worker": "^15.2.5",
+        "@octokit/rest": "^22.0.0",
         "@vercel/analytics": "^1.2.2",
         "@vercel/speed-insights": "^1.0.10",
         "file-saver": "^2.0.5",
@@ -3047,6 +3048,160 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/@octokit/auth-token": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+      "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.2.tgz",
+      "integrity": "sha512-ODsoD39Lq6vR6aBgvjTnA3nZGliknKboc9Gtxr7E4WDNqY24MxANKcuDQSF0jzapvGb3KWOEDrKfve4HoWGK+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^6.0.0",
+        "@octokit/graphql": "^9.0.1",
+        "@octokit/request": "^10.0.2",
+        "@octokit/request-error": "^7.0.0",
+        "@octokit/types": "^14.0.0",
+        "before-after-hook": "^4.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.0.tgz",
+      "integrity": "sha512-hoYicJZaqISMAI3JfaDr1qMNi48OctWuOih1m80bkYow/ayPw6Jj52tqWJ6GEoFTk1gBqfanSoI1iY99Z5+ekQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^14.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.1.tgz",
+      "integrity": "sha512-j1nQNU1ZxNFx2ZtKmL4sMrs4egy5h65OMDmSbVyuCzjOcwsHq6EaYjOTGXPQxgfiN8dJ4CriYHk6zF050WEULg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^10.0.2",
+        "@octokit/types": "^14.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "25.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.1.0.tgz",
+      "integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-13.1.0.tgz",
+      "integrity": "sha512-16iNOa4rTTjaWtfsPGJcYYL79FJakseX8TQFIPfVuSPC3s5nkS/DSNQPFPc5lJHgEDBWNMxSApHrEymNblhA9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^14.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
+      "integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-16.0.0.tgz",
+      "integrity": "sha512-kJVUQk6/dx/gRNLWUnAWKFs1kVPn5O5CYZyssyEoNYaFedqZxsfYs7DwI3d67hGz4qOwaJ1dpm07hOAD1BXx6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^14.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.2.tgz",
+      "integrity": "sha512-iYj4SJG/2bbhh+iIpFmG5u49DtJ4lipQ+aPakjL9OKpsGY93wM8w06gvFbEQxcMsZcCvk5th5KkIm2m8o14aWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.0",
+        "@octokit/request-error": "^7.0.0",
+        "@octokit/types": "^14.0.0",
+        "fast-content-type-parse": "^3.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.0.0.tgz",
+      "integrity": "sha512-KRA7VTGdVyJlh0cP5Tf94hTiYVVqmt2f3I6mnimmaVz4UG3gQV/k4mDJlJv3X67iX6rmN7gSHCF8ssqeMnmhZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^14.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.0.tgz",
+      "integrity": "sha512-z6tmTu9BTnw51jYGulxrlernpsQYXpui1RK21vmXn8yF5bp6iX16yfTtJYGK5Mh1qDkvDOmp2n8sRMcQmR8jiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/core": "^7.0.2",
+        "@octokit/plugin-paginate-rest": "^13.0.1",
+        "@octokit/plugin-request-log": "^6.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
+      "integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^25.1.0"
+      }
+    },
     "node_modules/@schematics/angular": {
       "version": "15.2.4",
       "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-15.2.4.tgz",
@@ -3992,6 +4147,12 @@
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
       "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
       "dev": true
+    },
+    "node_modules/before-after-hook": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+      "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/big.js": {
       "version": "5.2.2",
@@ -6176,6 +6337,22 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/fast-content-type-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
+      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -12088,6 +12265,12 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "license": "ISC"
     },
     "node_modules/universalify": {
       "version": "0.1.2",

--- a/src/app/components/mod-card/mod-card.component.html
+++ b/src/app/components/mod-card/mod-card.component.html
@@ -1,14 +1,14 @@
 <div class="p-4 w-full bg-white dark:bg-slate-800 dark:text-slate-200 rounded-lg shadow-md flex flex-col" *ngIf="view == View.List">
   <div class="overflow-y-auto flex gap-x-5">
   <div class="flex flex-col justify-center sm:order-first min-w-16 min-h-16">
-    <a *ngIf="view == View.List" href="https://modrinth.com/mod/{{project.slug}}" target="_blank" referrerpolicy="no-referrer" class="hidden sm:block" title="Open the Projects Modrinth Page"  tabindex="-1">
+    <a *ngIf="view == View.List && project.icon_url" href="https://modrinth.com/mod/{{project.slug}}" target="_blank" referrerpolicy="no-referrer" class="hidden sm:block" title="Open the Projects Modrinth Page"  tabindex="-1">
       <img src="{{project.icon_url}}" alt="{{project.title}}" class="aspect-square w-16 rounded-xl" style="background-color: {{project.color}}"/>
     </a>
   </div>
   <div class="flex flex-col flex-grow order-last sm:order-first">
     <div class="flex flex-row gap-x-1 items-baseline">
       <h2 class="text-lg font-bold dark:text-slate-100"><a class="hover:underline" href="{{project.project_url}}" target="_blank" referrerpolicy="no-referrer">{{project.title}}</a></h2>
-      <p>by <a class="underline" href="https://modrinth.com/user/{{selectedVersion.author_id}}" title="Open the Author's Modrinth Page" target="_blank" referrerpolicy="no-referrer">{{selectedVersion.author_id}}</a></p>
+      <p>by <a class="underline" href="{{authorUrl}}" title="{{authorLinkTitle}}" target="_blank" referrerpolicy="no-referrer">{{selectedVersion.author_id}}</a></p>
     </div>
     <p class="text-gray-700 dark:text-slate-200">{{project.description}}</p>
     <div class="flex flex-row gap-x-3 text-sm">
@@ -36,10 +36,9 @@
     </div>
   </div>
   <div class="flex flex-col justify-center flex-shrink items-center sm:items-start space-y-1 order-first sm:order-last">
-    <a *ngIf="view == View.List" href="https://modrinth.com/mod/{{project.slug}}" target="_blank" referrerpolicy="no-referrer" class="aspect-square sm:hidden" title="Open the Projects Modrinth Page"  tabindex="-1">
+    <a *ngIf="view == View.List && project.icon_url" href="https://modrinth.com/mod/{{project.slug}}" target="_blank" referrerpolicy="no-referrer" class="aspect-square sm:hidden" title="Open the Projects Modrinth Page"  tabindex="-1">
       <img src="{{project.icon_url}}" alt="{{project.title}}" class="h-8 w-8 rounded-lg"/>
     </a>
-
     <div class="flex flex-row gap-x-1 items-center w-full justify-center sm:justify-start">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-4 h-4 text-gray-900 dark:text-slate-200">
         <path stroke-linecap="round" stroke-linejoin="round" d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 002.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 00-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75 2.25 2.25 0 00-.1-.664m-5.8 0A2.251 2.251 0 0113.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25zM6.75 12h.008v.008H6.75V12zm0 3h.008v.008H6.75V15zm0 3h.008v.008H6.75V18z" />
@@ -78,7 +77,7 @@
 
 <div class="p-4 w-full h-full items-center bg-white dark:bg-slate-800 dark:text-slate-200 rounded-lg shadow-md overflow-y-auto flex gap-x-5" *ngIf="view === View.Grid">
   <div class="flex flex-col justify-center min-w-16 min-h-16">
-    <a href="https://modrinth.com/mod/{{project.slug}}" target="_blank" referrerpolicy="no-referrer" class="" title="{{project.title}}" tabindex="-1">
+    <a *ngIf="project.icon_url" href="https://modrinth.com/mod/{{project.slug}}" target="_blank" referrerpolicy="no-referrer" class="" title="{{project.title}}" tabindex="-1">
       <img src="{{project.icon_url}}" alt="{{project.title}}" class="aspect-square w-16 rounded-xl"/>
     </a>
   </div>

--- a/src/app/components/mod-card/mod-card.component.ts
+++ b/src/app/components/mod-card/mod-card.component.ts
@@ -39,6 +39,22 @@ export class ModCardComponent {
     return (this.selectedVersion.files.find(f => f.primary) || this.selectedVersion.files[0]).url;
   }
 
+  get isGitHubMod() {
+    return this.selectedVersion.id.startsWith('github-');
+  }
+
+  get authorUrl() {
+    return this.isGitHubMod ?
+      `https://github.com/${this.selectedVersion.author_id}` :
+      `https://modrinth.com/user/${this.selectedVersion.author_id}`;
+  }
+
+  get authorLinkTitle() {
+    return this.isGitHubMod ?
+      "Open the Author's GitHub Profile" :
+      "Open the Author's Modrinth Page";
+  }
+
   toggleChangelog() {
     this.showChangelog = !this.showChangelog;
   }

--- a/src/app/components/mod-panel/mod-panel.component.ts
+++ b/src/app/components/mod-panel/mod-panel.component.ts
@@ -1,29 +1,9 @@
 import {Component, inject, OnDestroy, OnInit} from '@angular/core';
 import {FilesService} from "../../services/files.service";
-import {
-  concatMap,
-  delay,
-  finalize,
-  firstValueFrom,
-  forkJoin,
-  from, last,
-  map,
-  Observable,
-  of,
-  Subject,
-  Subscription,
-  take,
-  tap
-} from "rxjs";
+import {concatMap, delay, finalize, firstValueFrom, forkJoin, from, last, map, Observable, of, Subject, Subscription, tap} from "rxjs";
 import {MinecraftVersion, VersionsService} from "../../services/versions.service";
 import {HttpClient} from "@angular/common/http";
-import {
-  ModrinthProject,
-  ModrinthVersion,
-  AnnotatedError,
-  Modpack,
-  ProjectType
-} from "../../libraries/modrinth/types.modrinth";
+import {AnnotatedError, Modpack, ModrinthProject, ModrinthVersion, ProjectType} from "../../libraries/modrinth/types.modrinth";
 import {View} from "../mod-card/mod-card.component";
 import * as JSZip from "jszip";
 import {saveAs} from 'file-saver';
@@ -31,6 +11,7 @@ import {Loader, LoaderService} from "../../services/loader.service";
 import Swal from "sweetalert2";
 import {ModrinthService} from "../../services/modrinth.service";
 import {CurseforgeService} from "../../services/curseforge.service";
+import {GitHubService} from "../../services/github.service";
 import {InteroperabilityService} from "../../services/interoperability.service";
 import {CurseforgeFile} from "../../libraries/curseforge/types.curseforge";
 import {CurseforgeSupportService} from "../../services/curseforgeSupport.service";
@@ -77,6 +58,7 @@ export class ModPanelComponent implements OnInit, OnDestroy {
   private http = inject(HttpClient);
   private modrinth = inject(ModrinthService);
   private curseforge = inject(CurseforgeService);
+  private github = inject(GitHubService);
   private interoperability = inject(InteroperabilityService);
 
   /**
@@ -155,7 +137,7 @@ export class ModPanelComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Processes a file using Modrinth API with Curseforge fallback
+   * Processes a file using Modrinth API with GitHub and Curseforge fallbacks
    * @param file The file to process
    * @param mcVersion The selected minecraft version
    * @param hash The hash of the file
@@ -188,7 +170,13 @@ export class ModPanelComponent implements OnInit, OnDestroy {
     }
 
     try {
-      // Try Modrinth first
+      // Try GitHub first for pattern-matched files (more specific)
+      const githubResult = await this.tryGitHub(file, mcVersion);
+      if (githubResult) {
+        return true;
+      }
+
+      // Try Modrinth second
       const modrinthResult = await this.tryModrinth(fileHash, file, mcVersion);
       if (modrinthResult) {
         return true;
@@ -196,14 +184,28 @@ export class ModPanelComponent implements OnInit, OnDestroy {
 
       // If Curseforge support is not enabled return false
       if (!this.curseforgeSupport) {
+        if (!this.unavailableMods.some(m => m.file == file)) {
+          this.unresolvedMods.push({
+            file,
+            slug: undefined,
+            annotation: {error: {status: 404, message: "No matching mod found in enabled APIs"}}
+          });
+        }
         return false;
       }
+
       // If Modrinth fails, and we have the file buffer, try Curseforge
       if (fileBuffer) {
         const curseforgeResult = await this.tryCurseforge(fileBuffer, file, mcVersion);
         if (curseforgeResult) return true;
       }
 
+      // All APIs failed, add to unresolved
+      this.unresolvedMods.push({
+        file,
+        slug: undefined,
+        annotation: {error: {status: 404, message: "No matching mod found in any API"}}
+      });
       return false;
     } catch (error: any) {
       console.error(`Error processing file ${file.name}:`, error);
@@ -323,6 +325,42 @@ export class ModPanelComponent implements OnInit, OnDestroy {
   }
 
   /**
+   * Attempts to process the file using GitHub API
+   * @param file The file to process
+   * @param mcVersion The selected minecraft version
+   * @private
+   */
+  private async tryGitHub(file: File, mcVersion: MinecraftVersion): Promise<boolean> {
+    const modInfo = await firstValueFrom(this.github.getModInfoForFile(file.name, this.loader, mcVersion.version));
+
+    if (!modInfo) {
+      return false;
+    }
+
+    this.removePreviousErrors(file);
+
+    // Convert GitHub data to Modrinth format using interoperability service
+    const modrinthProject = this.interoperability.convertGitHubToModrinthProject(modInfo, mcVersion.version);
+    const modrinthVersions = this.interoperability.convertGitHubToModrinthVersions(
+      modInfo.versions,
+      modInfo.project.id,
+      mcVersion.version,
+      modInfo.config.owner
+    );
+
+    // Set the correct loaders for the versions
+    modrinthVersions.forEach(version => {
+      version.loaders = modInfo.project.loaders;
+    });
+
+    // Create a mock installed version for comparison
+    const installedVersion = this.interoperability.createGitHubInstalledVersion(file.name, modInfo.project.id, modInfo.config.owner);
+
+    this.addToAvailableMods(modrinthProject, modrinthVersions, installedVersion);
+    return true;
+  }
+
+  /**
    * Loads version data from the modrinth API
    * @param fileHash The hash of the file
    * @param file The file to process
@@ -331,7 +369,7 @@ export class ModPanelComponent implements OnInit, OnDestroy {
   private async loadVersionData(fileHash: string, file: File) {
     const versionData = await firstValueFrom(this.modrinth.getVersionFromHash(fileHash));
     if (this.modrinth.isAnnotatedError(versionData)) {
-      await this.handleAnnotatedError(versionData, file);
+      await this.handleAnnotatedErrorSilent(versionData, file);
       return null;
     }
     return versionData;
@@ -346,7 +384,7 @@ export class ModPanelComponent implements OnInit, OnDestroy {
   private async loadProjectData(projectId: string, file: File) {
     const projectData = await firstValueFrom(this.modrinth.getProject(projectId));
     if (this.modrinth.isAnnotatedError(projectData)) {
-      await this.handleAnnotatedError(projectData, file, projectId);
+      await this.handleAnnotatedErrorSilent(projectData, file, projectId);
       return null;
     }
 
@@ -372,7 +410,7 @@ export class ModPanelComponent implements OnInit, OnDestroy {
       this.modrinth.getVersionsFromId(projectId, version, validLoaders)
     );
     if (this.modrinth.isAnnotatedError(targetVersionData)) {
-      await this.handleAnnotatedError(targetVersionData, file);
+      await this.handleAnnotatedErrorSilent(targetVersionData, file);
       return null;
     }
     return targetVersionData;
@@ -483,6 +521,31 @@ export class ModPanelComponent implements OnInit, OnDestroy {
     if (errorData.error.status !== 0) {
       this.unresolvedMods.push({file, slug, annotation: errorData});
     }
+  }
+
+  /**
+   * Handles annotated errors silently (without adding to unresolved mods immediately)
+   * Used during API fallback attempts to avoid premature unresolved classification
+   * @param errorData The error data
+   * @param file The file that caused the error
+   * @param slug The slug of the project
+   * @private
+   */
+  private async handleAnnotatedErrorSilent(errorData: any, file: File, slug?: string) {
+    if (errorData.error.status === 410) {
+      await Swal.fire({
+        position: "top-end",
+        icon: "error",
+        title: "API Deprecated",
+        text: "The Modrinth API has been deprecated. Please notify the maintainer on GitHub.",
+        showConfirmButton: false,
+        timer: 3000,
+        backdrop: "rgba(0, 0, 0, 0.0)",
+      });
+    } else if (errorData.error.status !== 404) {
+      this.handleRequestError(file);
+    }
+    // Note: We don't add to unresolvedMods here - that's handled by the caller after all APIs are tried
   }
 
 
@@ -719,17 +782,17 @@ export class ModPanelComponent implements OnInit, OnDestroy {
             fetch(file.url).then(async r => {
               zip.file(file.filename, await r.blob());
               completed++;
-              Swal.update({ html: `Progress: <b>${Math.round((completed / total) * 100)}%</b>`});
+              Swal.update({html: `Progress: <b>${Math.round((completed / total) * 100)}%</b>`});
               Swal.showLoading()
             })
           );
 
           await Promise.all(promises);
 
-          Swal.update({ title: 'Creating ZIP...', html: 'Please wait...' });
+          Swal.update({title: 'Creating ZIP...', html: 'Please wait...'});
           Swal.showLoading();
 
-          zip.generateAsync({ type: 'blob' }).then(content => {
+          zip.generateAsync({type: 'blob'}).then(content => {
             saveAs(content, 'mods.zip');
             Swal.close();
           });

--- a/src/app/components/mod-panel/mod-panel.component.ts
+++ b/src/app/components/mod-panel/mod-panel.component.ts
@@ -354,7 +354,7 @@ export class ModPanelComponent implements OnInit, OnDestroy {
     });
 
     // Create a mock installed version for comparison
-    const installedVersion = this.interoperability.createGitHubInstalledVersion(file.name, modInfo.project.id, modInfo.config.owner);
+    const installedVersion = this.interoperability.createGitHubInstalledVersion(file.name, modInfo.project.id);
 
     this.addToAvailableMods(modrinthProject, modrinthVersions, installedVersion);
     return true;

--- a/src/app/libraries/github/github.ts
+++ b/src/app/libraries/github/github.ts
@@ -1,0 +1,259 @@
+import {AnnotatedError, GitHubModInfo, GitHubProject, GitHubRelease, GitHubRepoConfig, GitHubVersion} from './types.github';
+import {catchError, delay, filter, map, Observable, of, retryWhen, scan, timeout} from 'rxjs';
+import {HttpClient, HttpErrorResponse, HttpResponse} from '@angular/common/http';
+import {inject} from '@angular/core';
+import {Loader} from '../../services/loader.service';
+import Swal from 'sweetalert2';
+
+export class GitHub {
+  private static _instance: GitHub;
+
+  public githubAPIUrl = 'https://api.github.com';
+  public headers = {
+    'Accept': 'application/vnd.github.v3+json',
+    'Content-Type': 'application/json'
+  };
+
+  private _rateLimit_Limit: number = 60;
+  private _rateLimit_Remaining: number = 60;
+  private _rateLimit_Reset: number = 0;
+
+  constructor() {
+  }
+
+  private http = inject(HttpClient);
+
+  public static get Instance() {
+    return this._instance || (this._instance = new this());
+  }
+
+  get rateLimit_Limit(): number {
+    return this._rateLimit_Limit;
+  }
+
+  get rateLimit_Remaining(): number {
+    return this._rateLimit_Remaining;
+  }
+
+  get rateLimit_Reset(): number {
+    return this._rateLimit_Reset;
+  }
+
+  /**
+   * Predefined GitHub repository configurations
+   */
+  public static REPO_CONFIGS: GitHubRepoConfig[] = [
+
+  ];
+  static {
+    for (const modName of ['litematica', 'malilib', 'minihud', 'tweakeroo', 'itemscroller']) {
+      GitHub.REPO_CONFIGS.push({
+        owner: 'sakura-ryoko',
+        repo: modName,
+        loader: Loader.fabric,
+        pattern: new RegExp(`^${modName}-fabric-.+?-.+?-sakura\\.\\d+?\\.jar$`, 'i')
+      });
+    }
+  }
+
+  /**
+   * Checks if the given object is an annotated error
+   * @param object The object to check
+   */
+  public isAnnotatedError(object: any): object is AnnotatedError {
+    return object && !!((object as AnnotatedError).error);
+  }
+
+  /**
+   * Adjusts the rate limit based on response headers
+   * @param headers The response headers
+   */
+  private adjustRateLimit(headers: any) {
+    const limit = headers.get('X-RateLimit-Limit');
+    const remaining = headers.get('X-RateLimit-Remaining');
+    const reset = headers.get('X-RateLimit-Reset');
+
+    if (limit) this._rateLimit_Limit = parseInt(limit);
+    if (remaining) this._rateLimit_Remaining = parseInt(remaining);
+    if (reset) this._rateLimit_Reset = parseInt(reset) - Math.floor(Date.now() / 1000);
+  }
+
+  private rateLimitHandler<T>(error: HttpErrorResponse): Observable<T> {
+    if (error.status === 403 && error.headers.get('X-RateLimit-Remaining') === '0') {
+      const resetTime = parseInt(error.headers.get('X-RateLimit-Reset') || '0');
+      const waitTime = Math.max(resetTime - Math.floor(Date.now() / 1000), 60);
+
+      console.log(`GitHub rate limit reached. Wait for ${waitTime} seconds before retrying.`);
+
+      Swal.fire({
+        position: 'top-end',
+        icon: 'warning',
+        title: 'GitHub Rate Limit',
+        text: `Rate limit reached. Waiting ${waitTime} seconds...`,
+        showConfirmButton: false,
+        timer: 3000,
+        backdrop: 'rgba(0, 0, 0, 0.0)',
+      });
+    }
+
+    return of({error: error} as T);
+  }
+
+  /**
+   * Returns an error handler that handles GitHub API errors
+   */
+  private errorHandler<T>() {
+    return (error: HttpErrorResponse): Observable<T> => {
+      if (error.status === 403) {
+        return this.rateLimitHandler(error);
+      }
+      return of({error: error} as T);
+    };
+  }
+
+  /**
+   * Retries the request with a backoff strategy
+   * @param maxRetries The maximum number of retries
+   * @param delayMs The delay in milliseconds
+   */
+  private retryWithBackoff(maxRetries: number, delayMs: number) {
+    return retryWhen(errors =>
+      errors.pipe(
+        scan((acc, error) => {
+          if (acc >= maxRetries) throw error;
+          return acc + 1;
+        }, 0),
+        delay(delayMs)
+      )
+    );
+  }
+
+  /**
+   * Gets releases for a GitHub repository
+   */
+  public getReleases(config: GitHubRepoConfig): Observable<GitHubRelease[] | AnnotatedError> {
+    const owner = config.owner;
+    const repo = config.repo;
+    const url = `${this.githubAPIUrl}/repos/${owner}/${repo}/releases`;
+
+    return this.http.get<GitHubRelease[]>(url, {
+      headers: this.headers,
+      observe: 'response'
+    }).pipe(
+      timeout(10000),
+      // @ts-ignore
+      this.retryWithBackoff(3, 1000),
+      map((resp: HttpResponse<GitHubRelease[]>) => {
+        this.adjustRateLimit(resp.headers);
+        return resp.body!.map(release => ({
+          ...release,
+          created_at: release.created_at,
+          published_at: release.published_at
+        }));
+      }),
+      catchError(this.errorHandler<GitHubRelease[] | AnnotatedError>())
+    );
+  }
+
+  /**
+   * Finds matching JAR asset in a release based on pattern
+   * @param release The GitHub release
+   * @param pattern The RegExp pattern to match
+   */
+  public findMatchingAsset(release: GitHubRelease, pattern: RegExp) {
+    return release.assets.find(asset =>
+      asset.name.endsWith('.jar') && pattern.test(asset.name)
+    );
+  }
+
+  /**
+   * Gets mod information for a filename that matches GitHub patterns
+   * @param filename The mod filename to check
+   * @param loader The current loader
+   * @param mcVersion The current selected minecraft version
+   */
+  public getModInfoForFile(filename: string, loader: Loader, mcVersion: string): Observable<GitHubModInfo | null> {
+    const matchingConfig = GitHub.REPO_CONFIGS.find(config =>
+      config.loader === loader && config.pattern.test(filename)
+    );
+
+    if (!matchingConfig) {
+      return of(null);
+    }
+
+    return this.getReleases(matchingConfig).pipe(
+      map(releases => {
+        if (this.isAnnotatedError(releases)) {
+          return null;
+        }
+
+        const validReleases = releases
+          .filter(release => !release.draft && !release.prerelease)
+          .filter(release => release.name.includes(mcVersion))
+          .filter(release => this.findMatchingAsset(release, matchingConfig.pattern));
+
+        if (validReleases.length === 0) {
+          return null;
+        }
+
+        const id = `${matchingConfig.owner}/${matchingConfig.repo}`;
+        const project: GitHubProject = {
+          id: id,
+          title: matchingConfig.repo,
+          description: 'Github Repository',
+          project_url: `https://github.com/${id}`,
+          downloads: validReleases.reduce((sum, release) =>
+            sum + release.assets.reduce((assetSum, asset) => assetSum + asset.download_count, 0), 0
+          ),
+          updated: new Date(Math.max(...validReleases.map(r => new Date(r.published_at).getTime()))),
+          versions: validReleases.map(r => r.tag_name),
+          loaders: [matchingConfig.loader]
+        };
+
+        const versions: GitHubVersion[] = validReleases.map(release => {
+          const asset = this.findMatchingAsset(release, matchingConfig.pattern)!;
+          const versionName = (release.name || release.tag_name);
+
+          return {
+            name: versionName,
+            version_number: release.tag_name,
+            changelog: release.body || '',
+            date_published: new Date(release.published_at),
+            downloads: asset.download_count,
+            files: [{
+              url: asset.browser_download_url,
+              filename: asset.name,
+              primary: true,
+              size: asset.size
+            }],
+            release_url: release.html_url
+          };
+        });
+
+        return {
+          project,
+          versions,
+          config: matchingConfig
+        };
+      })
+    );
+  }
+
+  /**
+   * Gets the latest version for a mod file
+   * @param filename The mod filename
+   * @param loader The current loader
+   * @param version The current selected minecraft version
+   */
+  public getLatestVersion(filename: string, loader: Loader, version: string): Observable<GitHubVersion | null> {
+    return this.getModInfoForFile(filename, loader, version).pipe(
+      map(modInfo => {
+        if (!modInfo || modInfo.versions.length === 0) {
+          return null;
+        }
+        // Return the most recent version (first in the sorted array)
+        return modInfo.versions[0];
+      })
+    );
+  }
+}

--- a/src/app/libraries/github/types.github.ts
+++ b/src/app/libraries/github/types.github.ts
@@ -1,0 +1,72 @@
+import { Loader } from '../../services/loader.service';
+
+export interface AnnotatedError {
+  error: {
+    message: string;
+    status: number;
+  };
+}
+
+export interface GitHubRepoConfig {
+  owner: string;
+  repo: string;
+  loader: Loader;
+  pattern: RegExp;
+}
+
+export interface GitHubRelease {
+  id: number;
+  tag_name: string;
+  name: string;
+  body: string;
+  draft: boolean;
+  prerelease: boolean;
+  created_at: string;
+  published_at: string;
+  assets: GitHubAsset[];
+  html_url: string;
+}
+
+export interface GitHubAsset {
+  id: number;
+  name: string;
+  label: string | null;
+  content_type: string;
+  size: number;
+  download_count: number;
+  created_at: string;
+  updated_at: string;
+  browser_download_url: string;
+}
+
+export interface GitHubVersion {
+  name: string;
+  version_number: string;
+  changelog: string;
+  date_published: Date;
+  downloads: number;
+  files: {
+    url: string;
+    filename: string;
+    primary: boolean;
+    size: number;
+  }[];
+  release_url: string;
+}
+
+export interface GitHubProject {
+  id: string;
+  title: string;
+  description: string;
+  project_url: string;
+  downloads: number;
+  updated: Date;
+  versions: string[];
+  loaders: Loader[];
+}
+
+export interface GitHubModInfo {
+  project: GitHubProject;
+  versions: GitHubVersion[];
+  config: GitHubRepoConfig;
+}

--- a/src/app/libraries/github/types.github.ts
+++ b/src/app/libraries/github/types.github.ts
@@ -12,6 +12,8 @@ export interface GitHubRepoConfig {
   repo: string;
   loader: Loader;
   pattern: RegExp;
+  icon_url: string;
+  description: string
 }
 
 export interface GitHubRelease {
@@ -33,6 +35,7 @@ export interface GitHubAsset {
   label: string | null;
   content_type: string;
   size: number;
+  digest: string;
   download_count: number;
   created_at: string;
   updated_at: string;

--- a/src/app/libraries/interop/interoperability.ts
+++ b/src/app/libraries/interop/interoperability.ts
@@ -203,7 +203,7 @@ export class Interoperability {
             wiki_url: null,
             discord_url: null,
             donation_urls: null,
-            icon_url: null,
+            icon_url: modInfo.config.icon_url,
             color: null,
             team: 'unknown',
             moderators_message: null,
@@ -266,10 +266,9 @@ export class Interoperability {
      * Creates a mock installed version for GitHub mods for comparison
      * @param filename The filename of the installed mod
      * @param projectId The project ID
-     * @param authorId The author ID (repository owner)
      * @public
      */
-    public createGitHubInstalledVersion(filename: string, projectId: string, authorId: string): ModrinthVersion {
+    public createGitHubInstalledVersion(filename: string, projectId: string): ModrinthVersion {
         return {
             name: `Installed: ${filename}`,
             version_number: 'installed',
@@ -283,7 +282,7 @@ export class Interoperability {
             requested_status: null,
             id: `github-installed-${filename}`,
             project_id: projectId,
-            author_id: authorId,
+            author_id: 'github',
             date_published: new Date(0), // Very old date to ensure updates are detected
             downloads: 0,
             files: [{

--- a/src/app/services/github.service.ts
+++ b/src/app/services/github.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { GitHub } from '../libraries/github/github';
+
+/**
+ * Service that acts as a Wrapper around the GitHub API.
+ * (Adheres to the Singleton pattern)
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class GitHubService extends GitHub {
+  constructor() { 
+    super();
+  }
+}


### PR DESCRIPTION
If a JAR file's filename matches a certain URL pattern, fetch from a predefined Github repo's releases section

Currently I have set this up for the litematica, malilib, minihud, tweakaroo, and itemscroller mods.

Currently the descriptions and icon URLs are hardcoded, I may fix this later but it would be not easy to do so

Note: I have used AI to do some boilerplating (e.g. creating the annoying type objects for the APIs)